### PR TITLE
Fixing error on exit when using is_close_immediately on interactive module 

### DIFF
--- a/autoload/vimshell/hook.vim
+++ b/autoload/vimshell/hook.vim
@@ -25,6 +25,13 @@
 "=============================================================================
 
 function! vimshell#hook#call(hook_point, context, args)"{{{
+  " There are cases when this variable doesn't 
+  " exist 
+  " USE: 'b:interactive.is_close_immediately = 1' to replicate
+  if !exists('b:interactive')
+    return
+  end
+
   if !a:context.is_interactive
         \ || !has_key(b:interactive.hook_functions_table, a:hook_point)
     return

--- a/autoload/vimshell/interactive.vim
+++ b/autoload/vimshell/interactive.vim
@@ -293,6 +293,13 @@ function! vimshell#interactive#execute_pipe_out(is_insert)"{{{
   endif
 endfunction"}}}
 function! s:set_output_pos(is_insert)"{{{
+  " There are cases when this variable doesn't 
+  " exist 
+  " USE: 'b:interactive.is_close_immediately = 1' to replicate
+  if !exists('b:interactive')
+    return
+  end
+
   if b:interactive.type !=# 'terminal' &&
         \ has_key(b:interactive.process, 'eof') && !b:interactive.process.eof
     if a:is_insert


### PR DESCRIPTION
This bug was found when using ujihisa/repl plugin

The current code always assume there is a 'b:interactive' variable set on
the environment. This is not the case when we are using the statement

'b:interactive.is_close_immediately = 1'

It did complain at some point that the variable was non-existing, I added
an if statement that checked if the variable was there, before doing
anything.
