### PR TITLE
bugfix

### DIFF
--- a/autoload/vimshell/hook.vim
+++ b/autoload/vimshell/hook.vim
@@ -33,6 +33,7 @@ function! vimshell#hook#call(hook_point, context, args)"{{{
   end
 
   if !a:context.is_interactive
+        \ || !has_key(b:interactive, 'hook_functions_table')
         \ || !has_key(b:interactive.hook_functions_table, a:hook_point)
     return
   endif


### PR DESCRIPTION
lessしているときに

```
!!!Vim(if):E716: Key not present in Dictionary: hook_functions_table, a:hook_point) function vimshell#execute_current_line..vimshell#mappings#execute_line..<SNR>171_execute_command_line..vimshell#parser#eval_script..vimshell#hook#call, line 8!!!
```

みたいなエラーがでてました
