### PR TITLE
s:send_regionで文字列を取得するwindowがおかしい問題を修正

### DIFF
--- a/autoload/vimshell/interactive.vim
+++ b/autoload/vimshell/interactive.vim
@@ -126,6 +126,12 @@ function! s:send_region(line1, line2, string)"{{{
     return
   endif
 
+  let string = a:string
+  if string == ''
+    let string = join(getline(a:line1, a:line2), "\<LF>")
+  endif
+  let string .= "\<LF>"
+
   let winnr = bufwinnr(s:last_interactive_bufnr)
   if winnr <= 0
     " Open buffer.
@@ -145,12 +151,6 @@ function! s:send_region(line1, line2, string)"{{{
         \ && type !=# 'vimshell'
     return
   endif
-
-  let string = a:string
-  if string == ''
-    let string = join(getline(a:line1, a:line2), "\<LF>")
-  endif
-  let string .= "\<LF>"
 
   if type ==# 'interactive'
     " Save prompt.


### PR DESCRIPTION
唐突に失礼します。

VimShellInteractive利用中に、VimShellSendStringでshell側に渡される文字列が、
なぜかcurrent windowの物ではなく、shell側windowの同一行の文字列になってしまう、という
問題にあたってしまいました。

ソースを拝見していたところ、interactive.vimのs:send_region内で、
current windowからstringの内容を取得する前にshell側windowにwincmdされており、
このために誤った文字列が取得されていたようでした。
https://github.com/Shougo/vimshell/blob/master/autoload/vimshell/interactive.vim#L137

以前のコミットを拝見する限り、昔はstring取得後にwincmdされていたようなので、
https://github.com/Shougo/vimshell/commit/cf8f7926bd00ad60a0ec8674a769aff5808e193a#L9L149
この修正のエンバグかも？と踏んで、stringを取得するコードをwincmdされる前に移植してパッチにしました。

あまりvimscriptにも本ライブラリそのものにも詳しくないため、そもそも自分の使い方・設定のせいでしたら、申し訳ありません。
また、ろくにコミュニケーションを取らないまま送っているので、修正方法も不適切かもしれません。
それらの場合はズバッとrejectしてくださいm(_ _)m

お手間お掛けしますが、よろしくおねがいします。
