### PR TITLE
Don't set nocompatible

### DIFF
--- a/autoload/vimshell/commands/bg.vim
+++ b/autoload/vimshell/commands/bg.vim
@@ -134,7 +134,6 @@ function! vimshell#commands#bg#init(commands, context, options, interactive)"{{{
   call vimshell#cd(cwd)
 
   " Common.
-  setlocal nocompatible
   setlocal nolist
   setlocal buftype=nofile
   setlocal noswapfile

--- a/autoload/vimshell/commands/less.vim
+++ b/autoload/vimshell/commands/less.vim
@@ -140,7 +140,6 @@ function! s:init(commands, context, options, interactive)"{{{
   call vimshell#cd(cwd)
 
   " Common.
-  setlocal nocompatible
   setlocal nolist
   setlocal buftype=nofile
   setlocal noswapfile


### PR DESCRIPTION
set nocompatible すると、いくつかのオプションがVimの規定値に戻されます。これがすごく不便なので、その処理を削除するパッチを書きました。
setlocal nocompatible しているのは何か理由があるんでしょうか？
