### PR TITLE
fix altercmd to check if current line is user prompt

### DIFF
--- a/autoload/vimshell/altercmd.vim
+++ b/autoload/vimshell/altercmd.vim
@@ -26,7 +26,8 @@
 
 function! vimshell#altercmd#define(original, alternative) "{{{
   execute 'inoreabbrev <buffer><expr>' a:original
-        \ '(join(vimshell#get_current_args()) ==# "' . a:original  . '")?' 
+        \ '(join(vimshell#get_current_args()) ==# "' . a:original  . '") &&'
+        \ 'vimshell#check_user_prompt() ?'
         \ s:SID_PREFIX().'recursive_expand_altercmd('.string(a:original).')' ':' string(a:original)
   let b:vimshell.altercmd_table[a:original] = a:alternative
 endfunction"}}}


### PR DESCRIPTION
pythonインタプリタのプロンプトでaltercmd機能が誤爆していたので修正しました。

```
$ python
!!!Python 2.7.1+ (r271:86832, Sep 27 2012, 21:16:52) !!!
!!![GCC 4.5.2] on linux2!!!
!!!Type "help", "copyright", "credits" or "license" for more information.!!!
>>> {この行でaltercmdに登録しているキーを入力すると展開してしまう}
```
