### PR TITLE
change behavior of <Plug>(vimshell_enter) on history promopt line

### DIFF
--- a/autoload/vimshell.vim
+++ b/autoload/vimshell.vim
@@ -433,9 +433,6 @@ function! vimshell#get_prompt(...) "{{{
     return ''
   endif
 
-  if !exists('s:prompt')
-  endif
-
   return &filetype ==# 'vimshell' &&
         \ empty(b:vimshell.continuation) ?
         \ vimshell#get_context().prompt :

--- a/autoload/vimshell/mappings.vim
+++ b/autoload/vimshell/mappings.vim
@@ -280,22 +280,16 @@ function! vimshell#mappings#execute_line(is_insert) "{{{
   elseif line('.') != line('$')
     " History execution.
 
-    " Search next prompt.
-    let prompt = vimshell#escape_match(vimshell#get_prompt())
-    if vimshell#get_user_prompt() != ''
-      let nprompt = '^\[%\] '
-    else
-      let nprompt = '^' . prompt
+    if !vimshell#check_prompt('$')
+      " Create prompt line.
+      call append('$', vimshell#get_prompt())
     endif
 
-    let [next_line, next_col] = searchpos(nprompt, 'Wn')
+    " Set command on current line.
+    let line = vimshell#get_prompt_command()
+    call setline('$', vimshell#get_prompt() . line)
 
-    if next_line > 0 && next_line - line('.') > 1
-      execute printf('%s,%sdelete _', line('.')+1, next_line-1)
-
-      call vimshell#terminal#clear_highlight()
-      normal! k
-    endif
+    $
   endif
 
   call s:execute_command_line(a:is_insert, oldpos)


### PR DESCRIPTION
`<Plug>(vimshell_enter)`はこの挙動の方が好きなのでとりあえず変更してみました。
しかし、本当に欲しいのはbash/zshの`<C-r>`のようなコマンドなので、そういうコマンドがあるといいのですが、そういうコマンドはないでしょうか。(`<C-r>`のようなコマンドがないために履歴からの`<Plug>(vimshell_enter)`を多用するのですが、その際に新しいプロンプトで実行して欲しい)

bash/zshの`<C-r>`みたく、現在のプロンプトに履歴のコマンドを「呼び出す」ことができるコマンドがあればうれしいです。

pull reqというよりissuesに上げるべき内容かと思いましたが、コード変更したのでどうせならコードも一緒に相談しようと思いました。
