### PR TITLE
Fixed cursor position when paste prompt

### DIFF
--- a/autoload/vimshell/mappings.vim
+++ b/autoload/vimshell/mappings.vim
@@ -590,8 +590,9 @@ function! s:insert_enter() "{{{
 
   if line('.') != line('$')
     " Paste prompt line.
+    let save_col = col('.')
     call vimshell#mappings#_paste_prompt()
-    call cursor('$', 0)
+    call cursor('$', save_col)
   endif
 
   let prompt_len = vimshell#get_prompt_length()


### PR DESCRIPTION
以下の件なんですが...（割り込みすみません
https://twitter.com/ShougoMatsu/status/400373556665540608

最小構成

``` vim
set nocompatible

if has('vim_starting')
  set runtimepath+=~/.vim/bundle/vimproc.vim
  set runtimepath+=~/.vim/bundle/vimshell.vim
endif

filetype plugin indent on
```

![yywl869nbw](https://f.cloud.github.com/assets/943423/1531357/347e39ca-4c63-11e3-8ccc-f87b4ec7d56e.gif)

途中の位置で `i` を押しても、行頭に移動します。

`vimshell#mappings#_paste_prompt()` の呼び出しによりカーソルが最下行の行頭に移動するため、カラム位置を保存しておく必要があると思います。
