### PR TITLE
Undesirable buffer name

### DIFF
--- a/autoload/vimshell.vim
+++ b/autoload/vimshell.vim
@@ -883,10 +883,7 @@ function! s:initialize_vimshell(path, context) "{{{
   " Initialize variables.
   let b:vimshell = {}
 
-  " Change current directory.
   let b:vimshell.current_dir = a:path
-  call vimshell#cd(a:path)
-
   let b:vimshell.alias_table = {}
   let b:vimshell.galias_table = {}
   let b:vimshell.altercmd_table = {}
@@ -903,6 +900,9 @@ function! s:initialize_vimshell(path, context) "{{{
 
   " Default settings.
   call s:default_settings()
+
+  " Change current directory.
+  call vimshell#cd(a:path)
 
   call vimshell#set_context(a:context)
 

--- a/autoload/vimshell/commands/bg.vim
+++ b/autoload/vimshell/commands/bg.vim
@@ -138,8 +138,6 @@ function! vimshell#commands#bg#init(commands, context, options, interactive) "{{
 
   let [new_pos[2], new_pos[3]] = [bufnr('%'), getpos('.')]
 
-  call vimshell#cd(cwd)
-
   " Common.
   setlocal nolist
   setlocal buftype=nofile
@@ -157,6 +155,8 @@ function! vimshell#commands#bg#init(commands, context, options, interactive) "{{
   let &filetype = a:options['--filetype']
 
   let b:interactive = a:interactive
+
+  call vimshell#cd(cwd)
 
   " Set syntax.
   syn region   InteractiveError   start=+!!!+ end=+!!!+

--- a/autoload/vimshell/commands/iexe.vim
+++ b/autoload/vimshell/commands/iexe.vim
@@ -317,11 +317,11 @@ function! vimshell#commands#iexe#init(context, interactive, new_pos, old_pos, is
 
   let [a:new_pos[2], a:new_pos[3]] = [bufnr('%'), getpos('.')]
 
-  call vimshell#cd(cwd)
-
   let b:interactive = a:interactive
 
   call s:default_settings()
+
+  call vimshell#cd(cwd)
 
   let syntax = 'int-' . a:interactive.command
   let &filetype = syntax

--- a/autoload/vimshell/commands/less.vim
+++ b/autoload/vimshell/commands/less.vim
@@ -144,8 +144,6 @@ function! s:init(commands, context, options, interactive) "{{{
 
   let [new_pos[2], new_pos[3]] = [bufnr('%'), getpos('.')]
 
-  call vimshell#cd(cwd)
-
   " Common.
   setlocal nolist
   setlocal buftype=nofile
@@ -164,6 +162,8 @@ function! s:init(commands, context, options, interactive) "{{{
   setlocal filetype=vimshell-less
   let &syntax = a:options['--syntax']
   let b:interactive = a:interactive
+
+  call vimshell#cd(cwd)
 
   " Set syntax.
   syn region   InteractiveError

--- a/autoload/vimshell/commands/texe.vim
+++ b/autoload/vimshell/commands/texe.vim
@@ -224,9 +224,9 @@ function! s:init_bg(args, context) "{{{
     return
   endif
 
-  call vimshell#cd(cwd)
-
   call s:default_settings()
+
+  call vimshell#cd(cwd)
 
   let use_cygpty = vimshell#util#is_windows() &&
         \ a:args[0] =~ '^fakecygpty\%(\.exe\)\?$'


### PR DESCRIPTION
仕様かもしれませんが、バグと仮定してPRを送ります。
第一引数に current directory (に展開される表現) 以外を指定して `vimshell#start()` を呼ぶと、
buffer name に呼び出し前のパスがくっつきます。
`setlocal buftype=nofile` の後に `vimshell#cd()` を呼ぶことで解決するので、適当な位置に `vimshell#cd()` を移動しました。

現象:

```
ディレクトリ構成:
/a
/a/b
/a/b/c

current dir: /a/b

(1) normal -- current dir を指定. OK
:call vimshell#start(getcwd())
:echo bufname('%')
> [vimshell] - default

(2) abnormal (?) -- subdir を指定. 呼び出し前の位置が付く
:call vimshell#start('c')
:echo bufname('%')
> /a/b/[vimshell] - default

(3) abnormal (?) -- parent dir を指定. directory の差分が付く
:call vimshell#start('/a')
:echo bufname('%')
> b/[vimshell] - default
```

この挙動で困るケース:
1. vim-vcs の `vim#info()` を vimshell の prompt に使っている
2. `:VimFiler foo` で current directory 以外の位置にある repository を開く
3. `H` で vimshell を開く
4. `vim#info()` (で使っている `vim#detect()`) は `fnamemodify(vcs#expand('%'), ':p')` で検出位置を決めるため、正しい結果が返せない
