### PR TITLE
Fixed autocmd problem in vexe

### DIFF
--- a/autoload/vimshell/commands/vexe.vim
+++ b/autoload/vimshell/commands/vexe.vim
@@ -66,6 +66,7 @@ function! s:command.execute(args, context) "{{{
   if bufnr('%') != bufnr
     call vimshell#next_prompt(a:context)
     noautocmd call vimshell#helpers#restore_pos(pos)
+    doautocmd BufRead
     if options['--insert']
       startinsert
     else


### PR DESCRIPTION
`vexe help`や`vexe quit`した後に、移った先のバッファー(例えばhelpファイル)のsyntaxが付かない現象を修正しました。
