### PR TITLE
Better backward compatibility of vimshrc location

### DIFF
--- a/plugin/vimshell.vim
+++ b/plugin/vimshell.vim
@@ -47,7 +47,10 @@ let g:vimshell_max_directory_stack =
 let g:vimshell_vimshrc_path =
       \ substitute(fnamemodify(get(
       \   g:, 'vimshell_vimshrc_path',
-      \  (isdirectory(expand('~/.vim')) ? '~/.vim/vimshrc' : '~/.vimshrc')),
+      \  (isdirectory(expand('~/.vim'))
+      \   && (filereadable(expand('~/.vim/vimshrc'))
+      \       || !filereadable(expand('~/.vimshrc')))
+      \   ? '~/.vim/vimshrc' : '~/.vimshrc')),
       \  ':p'), '\\', '/', 'g')
 let g:vimshell_escape_colors =
       \ get(g:, 'vimshell_escape_colors', [


### PR DESCRIPTION
**Actual**

|`~/.vim`|`~/.vim/vimshrc`|`~/.vimshrc`|`g:vimshell_vimshrc_path`|
|---|---|---|---|
||||`~/.vimshrc`|
||| :heavy_check_mark: |`~/.vimshrc`|
| :heavy_check_mark: |||`~/.vim/vimshrc`|
| :heavy_check_mark: | :heavy_check_mark: ||`~/.vim/vimshrc`|
| :heavy_check_mark: || :heavy_check_mark: |`~/.vim/vimshrc`|
| :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |`~/.vim/vimshrc`|

**Change to**

|`~/.vim`|`~/.vim/vimshrc`|`~/.vimshrc`|`g:vimshell_vimshrc_path`|
|---|---|---|---|
||||`~/.vimshrc`|
||| :heavy_check_mark: |`~/.vimshrc`|
| :heavy_check_mark: |||`~/.vim/vimshrc`|
| :heavy_check_mark: | :heavy_check_mark: ||`~/.vim/vimshrc`|
| :heavy_check_mark: || :heavy_check_mark: |`~/.vimshrc`|
| :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |`~/.vim/vimshrc`|

5段目の `~/.vim あり, ~/.vim/vimshrc なし, ~/.vimshrc あり` の場合を変更し、`~/.vimshrc` をデフォルト値としました。