### PR TITLE
Tune local performance

### DIFF
--- a/autoload/vimshell/interactive.vim
+++ b/autoload/vimshell/interactive.vim
@@ -446,48 +446,29 @@ function! vimshell#interactive#hang_up(afile) "{{{
     stopinsert
   endif
 endfunction"}}}
-function! vimshell#interactive#decode_signal(signal) "{{{
-  if a:signal == 2
-    return 'SIGINT'
-  elseif a:signal == 3
-    return 'SIGQUIT'
-  elseif a:signal == 4
-    return 'SIGILL'
-  elseif a:signal == 6
-    return 'SIGABRT'
-  elseif a:signal == 8
-    return 'SIGFPE'
-  elseif a:signal == 9
-    return 'SIGKILL'
-  elseif a:signal == 11
-    return 'SIGSEGV'
-  elseif a:signal == 13
-    return 'SIGPIPE'
-  elseif a:signal == 14
-    return 'SIGALRM'
-  elseif a:signal == 15
-    return 'SIGTERM'
-  elseif a:signal == 10
-    return 'SIGUSR1'
-  elseif a:signal == 12
-    return 'SIGUSR2'
-  elseif a:signal == 17
-    return 'SIGCHLD'
-  elseif a:signal == 18
-    return 'SIGCONT'
-  elseif a:signal == 19
-    return 'SIGSTOP'
-  elseif a:signal == 20
-    return 'SIGTSTP'
-  elseif a:signal == 21
-    return 'SIGTTIN'
-  elseif a:signal == 22
-    return 'SIGTTOU'
-  else
-    return 'UNKNOWN'
-  endif
-endfunction"}}}
-
+" function! vimshell#interactive#decode_signal(signal) {{{
+let s:_signal_decode_table = {
+      \ 2: 'SIGINT',
+      \ 3: 'SIGQUIT',
+      \ 4: 'SIGILL',
+      \ 6: 'SIGABRT',
+      \ 8: 'SIGFPE',
+      \ 9: 'SIGKILL',
+      \ 11: 'SIGSEGV',
+      \ 13: 'SIGPIPE',
+      \ 14: 'SIGALRM',
+      \ 15: 'SIGTERM',
+      \ 10: 'SIGUSR1',
+      \ 12: 'SIGUSR2',
+      \ 17: 'SIGCHLD',
+      \ 18: 'SIGCONT',
+      \ 19: 'SIGSTOP',
+      \ 20: 'SIGTSTP',
+      \ 21: 'SIGTTIN',
+      \ 22: 'SIGTTOU'}
+function! vimshell#interactive#decode_signal(signal)
+  return get(s:_signal_decode_table, a:signal, 'UNKNOWN')
+endfunction " }}}
 function! vimshell#interactive#read(fd) "{{{
   if empty(a:fd) || a:fd.stdin == ''
     return ''


### PR DESCRIPTION
* Use dictionary instead of (sequential) number comparison

Lingrにちらりと書いたのと関連。

`vimshell#interactive#decode_signal()`の実装が`if`で数値の比較の連続だったのを辞書にしたところ、(この関数だけを走らせまくる)ベンチマークで比較したところ高速化しました。`O(n)`から`O(log n)`的な感じになったのだと思います (Vimの辞書のlookupの速度に依存)。可読性も悪化していないです。

ベンチマーク

```vim
function! s:vimshell_interactive_decode_signal(signal)
  if a:signal == 2
    return 'SIGINT'
  elseif a:signal == 3
    return 'SIGQUIT'
  elseif a:signal == 4
    return 'SIGILL'
  elseif a:signal == 6
    return 'SIGABRT'
  elseif a:signal == 8
    return 'SIGFPE'
  elseif a:signal == 9
    return 'SIGKILL'
  elseif a:signal == 11
    return 'SIGSEGV'
  elseif a:signal == 13
    return 'SIGPIPE'
  elseif a:signal == 14
    return 'SIGALRM'
  elseif a:signal == 15
    return 'SIGTERM'
  elseif a:signal == 10
    return 'SIGUSR1'
  elseif a:signal == 12
    return 'SIGUSR2'
  elseif a:signal == 17
    return 'SIGCHLD'
  elseif a:signal == 18
    return 'SIGCONT'
  elseif a:signal == 19
    return 'SIGSTOP'
  elseif a:signal == 20
    return 'SIGTSTP'
  elseif a:signal == 21
    return 'SIGTTIN'
  elseif a:signal == 22
    return 'SIGTTOU'
  else
    return 'UNKNOWN'
  endif
endfunction

let s:vimshell_interactive_decode_signal_table = {
      \ 2: 'SIGINT',
      \ 3: 'SIGQUIT',
      \ 4: 'SIGILL',
      \ 6: 'SIGABRT',
      \ 8: 'SIGFPE',
      \ 9: 'SIGKILL',
      \ 11: 'SIGSEGV',
      \ 13: 'SIGPIPE',
      \ 14: 'SIGALRM',
      \ 15: 'SIGTERM',
      \ 10: 'SIGUSR1',
      \ 12: 'SIGUSR2',
      \ 17: 'SIGCHLD',
      \ 18: 'SIGCONT',
      \ 19: 'SIGSTOP',
      \ 20: 'SIGTSTP',
      \ 21: 'SIGTTIN',
      \ 22: 'SIGTTOU'}
function! s:vimshell_interactive_decode_signal2(signal)
  return get(s:vimshell_interactive_decode_signal_table, a:signal, 'UNKNOWN')
endfunction

" Benchmark for the original implementation
"   my result: 1.293094 sec
let before = reltime()
for i in range(2000)
  for signal in range(2, 23)
    call s:vimshell_interactive_decode_signal(signal)
  endfor
endfor
echomsg reltimestr(reltime(before))

" Benchmark for the new implementation
"   my result: 0.486582 sec
let before = reltime()
for i in range(2000)
  for signal in range(2, 23)
    call s:vimshell_interactive_decode_signal2(signal)
  endfor
endfor
echomsg reltimestr(reltime(before))
```